### PR TITLE
proper error handling in entire application

### DIFF
--- a/cmd/release.go
+++ b/cmd/release.go
@@ -21,7 +21,14 @@ var releaseCmd = &cobra.Command{
 	Args:      cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 
-		cfg := config.LoadConfig()
+		cfg, err := config.LoadConfig()
+		if err != nil {
+			errors.Fatal(
+				"Loading Configuration Failed",
+				err.Error(),
+				errors.ErrConfigExists,
+			)
+		}
 
 		service := release.NewReleaseService(cfg)
 

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/nekoman-hq/neko-cli/internal/config"
+	"github.com/nekoman-hq/neko-cli/internal/errors"
 	"github.com/nekoman-hq/neko-cli/internal/log"
 	"github.com/spf13/cobra"
 )
@@ -17,7 +18,14 @@ var checkCmd = &cobra.Command{
 	Long: `Show or validate the Neko configuration.
 You can inspect your current .neko.json or run validations to ensure it is correct.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		cfg := config.LoadConfig()
+		cfg, err := config.LoadConfig()
+		if err != nil {
+			errors.Fatal(
+				"Loading Configuration failed",
+				err.Error(),
+				errors.ErrConfig,
+			)
+		}
 
 		if showConfig {
 			println(fmt.Sprintf("\n%s %s\n",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,114 +8,93 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"regexp"
 
-	"github.com/nekoman-hq/neko-cli/internal/errors"
 	"github.com/nekoman-hq/neko-cli/internal/log"
 )
 
 const configFileName = ".neko.json"
 
-func LoadConfig() *NekoConfig {
+func LoadConfig() (*NekoConfig, error) {
 
 	log.V(log.Config, "Loading config from file...")
 
 	data, err := os.ReadFile(configFileName)
 	if err != nil {
 		if os.IsNotExist(err) {
-			errors.Fatal(
-				"Configuration not found",
-				"No .neko.json configuration found. Run 'neko init' first.",
-				errors.ErrConfigNotExists,
+			return nil, errors.New(
+				"Configuration not found: No .neko.json configuration found. Run 'neko init' first.",
 			)
 		} else {
-			errors.Fatal(
-				"Configuration read error",
-				err.Error(),
-				errors.ErrConfigRead,
+			return nil, fmt.Errorf(
+				"Configuration read error: %w", err,
 			)
 		}
 	}
 
 	var config NekoConfig
 	if err := json.Unmarshal(data, &config); err != nil {
-		errors.Fatal(
-			"Configuration parse error",
-			"Failed to parse .neko.json: "+err.Error(),
-			errors.ErrConfigMarshal,
+		return nil, fmt.Errorf(
+			"Configuration parse error: %w", err,
 		)
 	}
 
 	Validate(&config)
 
-	return &config
+	return &config, nil
 }
 
 var semverRegex = regexp.MustCompile(
 	`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[\da-zA-Z-]+(?:\.[\da-zA-Z-]+)*)?(?:\+[\da-zA-Z-]+(?:\.[\da-zA-Z-]+)*)?$`,
 )
 
-func Validate(cfg *NekoConfig) {
+func Validate(cfg *NekoConfig) error {
 	log.V(log.Config, "Validating serialised config...")
 
 	if !cfg.ProjectType.IsValid() {
-		errors.Error(
-			"Invalid configuration",
-			"ProjectType is invalid in .neko.json",
-			errors.ErrConfigMarshal,
+		return errors.New(
+			"Invalid configuration: ProjectType is invalid in .neko.json",
 		)
-		return
 	}
 
 	if !cfg.ReleaseSystem.IsValid() {
-		errors.Error(
-			"Invalid configuration",
-			"ReleaseSystem is invalid in .neko.json",
-			errors.ErrConfigMarshal,
+		return errors.New(
+			"Invalid configuration: ReleaseSystem is invalid in .neko.json",
 		)
-		return
 	}
 
 	if cfg.Version == "" {
-		errors.Error(
-			"Invalid configuration",
-			"Version is missing in .neko.json",
-			errors.ErrConfigMarshal,
+		return errors.New(
+			"Invalid configuration: Version is missing in .neko.json",
 		)
-		return
 	}
 
 	if !semverRegex.MatchString(cfg.Version) {
-		errors.Error(
-			"Invalid configuration",
-			"Version is not a valid semantic version (SemVer)",
-			errors.ErrVersionViolation,
+		return errors.New(
+			"Invalid configuration: Version is not a valid semantic version (SemVer)",
 		)
-		return
 	}
 
 	log.Print(log.Config, "\uF00C Config appears valid")
+
+	return nil
 }
 
 func SaveConfig(config NekoConfig) error {
 	data, err := json.MarshalIndent(config, "", "  ")
 	if err != nil {
-		errors.Fatal(
-			"Configuration serialization failed",
-			"Could not marshal .neko.json: "+err.Error(),
-			errors.ErrConfigMarshal,
+		return fmt.Errorf(
+			"Configuration serialization failed: %w", err,
 		)
-		return err
 	}
 
 	if err := os.WriteFile(configFileName, data, 0644); err != nil {
-		errors.Fatal(
-			"Configuration write failed",
-			"Could not write .neko.json: "+err.Error(),
-			errors.ErrConfigWrite,
+		return fmt.Errorf(
+			"Configuration write failed: %w", err,
 		)
-		return err
 	}
 	return nil
 }

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -7,28 +7,24 @@ package config
 */
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
-	"github.com/nekoman-hq/neko-cli/internal/errors"
 	"github.com/nekoman-hq/neko-cli/internal/log"
 )
 
 // GetPAT retrieves the GitHub Personal Access Token from the environment.
-// It exits the program with a clear error message if the token is not set.
-func GetPAT() string {
+// returns error if the token is not set.
+func GetPAT() (string, error) {
 	log.V(log.Config, fmt.Sprintf("Looking up required env variable: %s",
 		log.ColorText(log.ColorGreen, "GITHUB_TOKEN"),
 	))
 	token, ok := os.LookupEnv("GITHUB_TOKEN")
 	if !ok || token == "" {
-		errors.Fatal(
-			"Environment Variable Missing",
-			"A GitHub Personal Access Token (GITHUB_TOKEN) is required.\nSet it with: export GITHUB_TOKEN=your_token_here",
-			errors.ErrMissingEnvVar,
+		return "", errors.New(
+			"Environment Variable Missing: \nA GitHub Personal Access Token (GITHUB_TOKEN) is required.\nSet it with: export GITHUB_TOKEN=your_token_here",
 		)
-		// Fatal should exit, so the return is technically never reached
-		return ""
 	}
-	return token
+	return token, nil
 }

--- a/internal/errors/error_codes.go
+++ b/internal/errors/error_codes.go
@@ -30,6 +30,7 @@ const (
 	ErrConfigWrite      = "NEKO_3005"
 	ErrConfigRead       = "NEKO_3006"
 	ErrVersionViolation = "NEKO_3007"
+	ErrConfig           = "NEKO_3008"
 
 	ErrInvalidReleaseType   = "NEKO_4000"
 	ErrInvalidReleaseSystem = "NEKO_4001"

--- a/internal/history/history.go
+++ b/internal/history/history.go
@@ -29,7 +29,11 @@ func ShowHistory() {
 
 // showBranch displays the current branch
 func showBranch() {
-	branch := git.CurrentBranch()
+	branch, err := git.CurrentBranch()
+	if err != nil {
+		return
+	}
+
 	fmt.Printf(" %s  %s \n",
 		log.ColorText(log.ColorGreen, "\uE725"),
 		branch,
@@ -38,7 +42,11 @@ func showBranch() {
 
 // showLastCommit displays the last commit information
 func showLastCommit() {
-	lastCommit := git.LastCommit()
+	lastCommit, err := git.LastCommit()
+	if err != nil {
+		return
+	}
+
 	fmt.Printf(" %s  %s \n",
 		log.ColorText(log.ColorYellow, "\uF172"),
 		lastCommit,
@@ -50,16 +58,23 @@ func showStatistics() {
 	log.V(log.History, "Gathering repository statistics")
 
 	// Total commits
-	totalCommits := git.TotalCommits()
+	totalCommits, err := git.TotalCommits()
+	if err != nil {
+	}
 
 	// Tags
 	tagList := git.GetTags()
-
 	// Files count
-	filesCount := git.FilesCount()
+	filesCount, err := git.FilesCount()
+	if err != nil {
+		return
+	}
 
 	// Repo size
-	repoSize := git.RepoSize()
+	repoSize, err := git.RepoSize()
+	if err != nil {
+		return
+	}
 
 	// Print statistics
 	fmt.Println(log.ColorText(log.ColorCyan, "\n┌─ \uF201 Statistics"))
@@ -80,6 +95,7 @@ func showStatistics() {
 			log.ColorText(log.ColorCyan, "│"),
 			log.ColorText(log.ColorBlue, repoSize),
 		)
+
 	}
 	fmt.Println(log.ColorText(log.ColorCyan, "│"))
 }
@@ -96,7 +112,7 @@ func showTagHistory() {
 
 	fmt.Println(log.ColorText(log.ColorCyan, "├─ \U000F04F9 Tag History"))
 
-	for i := 0; i < len(tagList); i++ {
+	for i := range tagList {
 		var commitCount int
 		var prefix string
 
@@ -134,7 +150,10 @@ func showTagHistory() {
 func showContributors() {
 	fmt.Println(log.ColorText(log.ColorCyan, "└─ \uF4FE Contributors"))
 
-	contributors := git.Contributors()
+	contributors, err := git.Contributors()
+	if err != nil {
+		return
+	}
 
 	for i, contributor := range contributors {
 		var prefix string

--- a/internal/init/init.go
+++ b/internal/init/init.go
@@ -8,15 +8,17 @@ package init
 */
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/nekoman-hq/neko-cli/internal/config"
-	"github.com/nekoman-hq/neko-cli/internal/errors"
 	"github.com/nekoman-hq/neko-cli/internal/git"
 	"github.com/nekoman-hq/neko-cli/internal/release"
 )
 
-func Run(info *git.RepoInfo) {
+func Run(info *git.RepoInfo) error {
 	if !confirmOverwriteIfExists() {
-		return
+		return nil
 	}
 
 	cfg := runWizard()
@@ -27,32 +29,26 @@ func Run(info *git.RepoInfo) {
 	}
 
 	if err := config.SaveConfig(cfg); err != nil {
-		errors.Fatal(
-			"Configuration write failed",
-			err.Error(),
-			errors.ErrConfigWrite,
+		return fmt.Errorf(
+			"Configuration write failed: %w", err,
 		)
-		return
 	}
 
 	releaser, err := release.Get(string(cfg.ReleaseSystem))
 	if err != nil {
-		errors.Fatal(
-			"Release System Not Found",
-			err.Error(),
-			errors.ErrInvalidReleaseSystem,
+		return fmt.Errorf(
+			"Release System Not Found: %w", err,
 		)
 	}
 
 	err = releaser.Init(&cfg)
 	if err != nil {
-		errors.Fatal(
+		return errors.New(
 			"Release system initialization failed",
-			"Failed to initialize the release system.",
-			errors.ErrReleaseSystemInit,
 		)
-		return
 	}
 
 	printSetupInstructions(cfg)
+
+	return nil
 }

--- a/internal/release/resolver.go
+++ b/internal/release/resolver.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/Masterminds/semver/v3"
-	"github.com/nekoman-hq/neko-cli/internal/errors"
 	"github.com/nekoman-hq/neko-cli/internal/log"
 )
 
@@ -28,10 +27,9 @@ func ResolveReleaseType(version *semver.Version, args []string, t Tool) (Type, e
 	if len(args) > 0 {
 		rt, err := ParseReleaseType(args[0])
 		if err != nil {
-			errors.Fatal(
-				"Not a valid increment",
-				"The given type is not valid increment option.",
-				errors.ErrInvalidReleaseType,
+			var zero Type
+			return zero, fmt.Errorf(
+				"Not a valid increment: %w", err,
 			)
 		}
 
@@ -48,10 +46,9 @@ func ResolveReleaseType(version *semver.Version, args []string, t Tool) (Type, e
 	}
 
 	if !t.SupportsSurvey() {
-		errors.Fatal(
-			"Interactive mode not supported",
-			fmt.Sprintf("%s requires an explicit release type", t.Name()),
-			errors.ErrSurveyFailed,
+		var zero Type
+		return zero, fmt.Errorf(
+			"Interactive mode not supported: %s requires an explicit release type", t.Name(),
 		)
 	}
 

--- a/internal/release/tool/releaseit/release_it.go
+++ b/internal/release/tool/releaseit/release_it.go
@@ -9,12 +9,24 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/nekoman-hq/neko-cli/internal/config"
 	"github.com/nekoman-hq/neko-cli/internal/errors"
+	"github.com/nekoman-hq/neko-cli/internal/git"
 	"github.com/nekoman-hq/neko-cli/internal/log"
 	"github.com/nekoman-hq/neko-cli/internal/release"
 )
 
 type ReleaseIt struct {
 	release.ToolBase
+
+	State struct {
+		PreHead           string
+		ReleaseCommitHash string
+
+		TagName      string
+		PushedCommit bool
+		PushedTag    bool
+
+		CreatedGitHubRelease bool
+	}
 }
 
 func (r *ReleaseIt) Name() string {
@@ -22,17 +34,45 @@ func (r *ReleaseIt) Name() string {
 }
 
 func (r *ReleaseIt) Init(cfg *config.NekoConfig) error {
-	r.RequireBinary("npm")
-	r.runReleaseItInit(cfg)
-	r.runReleaseItCheck()
+	if err := r.RequireBinary("npm"); err != nil {
+		return err
+	}
+
+	if err := r.runReleaseItInit(cfg); err != nil {
+		return err
+	}
+
+	if err := r.runReleaseItCheck(); err != nil {
+		return err
+	}
 
 	return nil
 }
 
 func (r *ReleaseIt) Release(v *semver.Version) error {
+	pre, err := git.Head()
+	if err != nil {
+		return err
+	}
+	r.State.PreHead = pre
+
 	if err := r.runReleaseItRelease(v); err != nil {
 		return err
 	}
+
+	head, err := git.Head()
+	if err != nil {
+		return err
+	}
+	r.State.ReleaseCommitHash = head
+
+	r.State.TagName = fmt.Sprintf("v%s", v.String())
+
+	r.State.PushedCommit = true
+	r.State.PushedTag = true
+
+	r.State.CreatedGitHubRelease = true
+
 	return nil
 }
 
@@ -44,21 +84,30 @@ func (r *ReleaseIt) SupportsSurvey() bool {
 	return true
 }
 
-func (r *ReleaseIt) runReleaseItInit(cfg *config.NekoConfig) {
+func (r *ReleaseIt) RevertRelease() error {
+	return r.RevertGitRelease(release.GitReleaseState{
+		PreHead:              r.State.PreHead,
+		ReleaseHead:          r.State.ReleaseCommitHash,
+		TagName:              r.State.TagName,
+		PushedCommit:         r.State.PushedCommit,
+		PushedTag:            r.State.PushedTag,
+		GitHubReleaseTag:     r.State.TagName,
+		CreatedGitHubRelease: r.State.CreatedGitHubRelease,
+	})
+}
+
+func (r *ReleaseIt) runReleaseItInit(cfg *config.NekoConfig) error {
 	if _, err := os.Stat(".release-it.json"); err == nil {
 		log.Print(
 			log.Init,
 			"Skipping ReleaseIt init, %s already exists",
 			log.ColorText(log.ColorCyan, ".release-it.json"),
 		)
-		return
+		return nil
 	} else if !os.IsNotExist(err) {
-		errors.Fatal(
-			"Failed to check .release-it.json",
-			err.Error(),
-			errors.ErrFileAccess,
+		return fmt.Errorf(
+			"Failed to check .release-it.json: %w", err,
 		)
-		return
 	}
 
 	if _, err := os.Stat("package.json"); os.IsNotExist(err) {
@@ -77,19 +126,17 @@ func (r *ReleaseIt) runReleaseItInit(cfg *config.NekoConfig) {
 	cmd := exec.Command("npm", "install", "-D", "release-it")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		errors.Fatal(
-			"Failed to initialize release-it",
-			fmt.Sprintf("Command failed: %s\nOutput: %s", err.Error(), string(output)),
-			errors.ErrDependencyMissing,
+		return fmt.Errorf(
+			"Failed to initialize release-it: %s: %w", string(output), err,
 		)
 	}
 
 	rcfg, err := InitDefaultConfig(cfg.ProjectName)
 	if err != nil {
-		errors.Fatal("Failed to create default config", err.Error(), errors.ErrFileAccess)
+		return fmt.Errorf("Failed to create default config: %w", err)
 	}
 	if err := SaveConfig(rcfg); err != nil {
-		errors.Fatal("Failed to save .release-it.json", err.Error(), errors.ErrFileAccess)
+		return fmt.Errorf("Failed to save .release-it.json: %w", err)
 	}
 
 	log.Print(
@@ -97,9 +144,11 @@ func (r *ReleaseIt) runReleaseItInit(cfg *config.NekoConfig) {
 		"\uF00C  Successfully initialized %s",
 		log.ColorText(log.ColorCyan, "release-it"),
 	)
+
+	return nil
 }
 
-func (r *ReleaseIt) runReleaseItCheck() {
+func (r *ReleaseIt) runReleaseItCheck() error {
 	log.V(log.Init,
 		fmt.Sprintf("Verifying release-it installation: %s",
 			log.ColorText(log.ColorGreen, "npx release-it -v"),
@@ -108,10 +157,8 @@ func (r *ReleaseIt) runReleaseItCheck() {
 	cmd := exec.Command("npx", "release-it", "-v")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		errors.Fatal(
-			"Failed to verify release-it installation",
-			fmt.Sprintf("Command failed: %s\nOutput: %s", err.Error(), string(output)),
-			errors.ErrDependencyMissing,
+		return fmt.Errorf(
+			"Failed to verify release-it installation: %s: %w", string(output), err,
 		)
 	}
 	log.Print(
@@ -120,6 +167,8 @@ func (r *ReleaseIt) runReleaseItCheck() {
 		log.ColorText(log.ColorCyan, "release-it"),
 		log.ColorText(log.ColorGreen, string(output)),
 	)
+
+	return nil
 }
 
 func (r *ReleaseIt) runReleaseItRelease(v *semver.Version) error {

--- a/internal/release/version_guard.go
+++ b/internal/release/version_guard.go
@@ -16,7 +16,7 @@ import (
 	"github.com/nekoman-hq/neko-cli/internal/log"
 )
 
-func VersionGuard(cfg *config.NekoConfig) *semver.Version {
+func VersionGuard(cfg *config.NekoConfig) (*semver.Version, error) {
 	log.V(log.VersionGuard, "Running Version Guard checks")
 	git.Fetch()
 
@@ -25,13 +25,11 @@ func VersionGuard(cfg *config.NekoConfig) *semver.Version {
 	return EnsureVersionIsValid(cfg, latestTag)
 }
 
-func EnsureVersionIsValid(cfg *config.NekoConfig, latestTag string) *semver.Version {
+func EnsureVersionIsValid(cfg *config.NekoConfig, latestTag string) (*semver.Version, error) {
 	localVer, err := semver.NewVersion(cfg.Version)
 	if err != nil {
-		errors.Fatal(
-			"Invalid local version",
-			fmt.Sprintf("Version %s in .neko.json is not a valid semantic version", cfg.Version),
-			errors.ErrVersionViolation,
+		return nil, fmt.Errorf(
+			"Version %s in .neko.json is not a valid semantic version", cfg.Version,
 		)
 	}
 
@@ -48,18 +46,14 @@ func EnsureVersionIsValid(cfg *config.NekoConfig, latestTag string) *semver.Vers
 			),
 		)
 
-		return localVer
+		return localVer, nil
 	}
 
 	if localVer.LessThan(remoteVer) {
-		errors.Fatal(
-			"Version violation",
-			fmt.Sprintf(
-				"Local version %s is smaller than latest tag %s",
-				localVer,
-				remoteVer,
-			),
-			errors.ErrVersionViolation,
+		return nil, fmt.Errorf(
+			"Version violation: Local version %s is smaller than latest tag %s",
+			localVer,
+			remoteVer,
 		)
 	}
 
@@ -71,5 +65,5 @@ func EnsureVersionIsValid(cfg *config.NekoConfig, latestTag string) *semver.Vers
 		),
 	)
 
-	return localVer
+	return localVer, nil
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -24,13 +24,16 @@ var (
 	BuiltBy = "unknown"
 )
 
-func Latest(repoInfo *git.RepoInfo) {
-	release := git.LatestRelease(repoInfo)
-	displayCLIVersion()
-
-	if release != nil {
-		displayRelease(repoInfo, release)
+func Latest(repoInfo *git.RepoInfo) error {
+	release, err := git.LatestRelease(repoInfo)
+	if err != nil {
+		return err
 	}
+
+	displayCLIVersion()
+	displayRelease(repoInfo, release)
+
+	return nil
 }
 
 func displayCLIVersion() {


### PR DESCRIPTION
This PR tackles permature panics on errors in the application, which leave the application in an unconsisten and broken state, and propagates them instead. With these changes I could also introduce a 'rollback' system for the `release` command. 

When an error during releasing happens it cleans up and reverts the release. This affects
 - created commits
 - tags
 - remote pushes
 - remote tags
 - github releases
 
 > [!Note]
 > this may have unbeautified a few error messages. 

fixes #4